### PR TITLE
Broken URLs on the test results page

### DIFF
--- a/classes/controller/unittest.php
+++ b/classes/controller/unittest.php
@@ -227,6 +227,7 @@ class Controller_UnitTest extends Controller_Template
 			->set('group',  Arr::get($this->get_groups_list($suite), reset($group), 'All groups'))
 			->set('groups', $this->get_groups_list($suite))
 
+			->set('run_uri',        $this->request->uri())
 			->set('report_uri',     $this->report_uri.url::query())
 
 			// Whitelist related stuff

--- a/classes/controller/unittest.php
+++ b/classes/controller/unittest.php
@@ -164,7 +164,7 @@ class Controller_UnitTest extends Controller_Template
 
 			$runner->generate_report($group, $path, FALSE);
 
-			$this->request->redirect(URL::base(FALSE, TRUE).$folder.'index.html');
+			$this->request->redirect(URL::site($folder.'index.html', $this->request));
 		}
 	}
 

--- a/views/unittest/results.php
+++ b/views/unittest/results.php
@@ -2,7 +2,7 @@
 <div id="header" class="results">
 	<fieldset id="results-options">
 		<legend>Options</legend>
-		<?php echo Form::open(NULL, array('method' => 'get'));?>
+		<?php echo Form::open($run_uri, array('method' => 'get'));?>
 		<?php echo Form::label('group', __('Switch Group')) ?>
 		<?php echo Form::select('group', $groups, $group, array('id' => 'group'));?>
 		<?php if ($xdebug_enabled): ?>


### PR DESCRIPTION
It's a pretty simple change.
