### PR TITLE
Eliminating coding standard violations from unittest module (3.0)

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -57,15 +57,21 @@ define('DOCROOT', realpath(dirname(__FILE__)).DIRECTORY_SEPARATOR);
 
 // Make the application relative to the docroot
 if ( ! is_dir($application) AND is_dir(DOCROOT.$application))
+{
 	$application = DOCROOT.$application;
+}
 
 // Make the modules relative to the docroot
 if ( ! is_dir($modules) AND is_dir(DOCROOT.$modules))
+{
 	$modules = DOCROOT.$modules;
+}
 
 // Make the system relative to the docroot
 if ( ! is_dir($system) AND is_dir(DOCROOT.$system))
+{
 	$system = DOCROOT.$system;
+}
 
 // Define the absolute paths for configured directories
 define('APPPATH', realpath($application).DIRECTORY_SEPARATOR);

--- a/classes/controller/unittest.php
+++ b/classes/controller/unittest.php
@@ -73,10 +73,10 @@ Class Controller_UnitTest extends Controller_Template
 		// This just stops some very very long lines
 		$route = Route::get('unittest');
 		$this->report_uri = $route->uri(array('action' => 'report'));
-		$this->run_uri    = $route->uri(array('action' => 'run'));
+		$this->run_uri = $route->uri(array('action' => 'run'));
 
 		// Switch used to disable cc settings
-		$this->xdebug_loaded      = extension_loaded('xdebug');
+		$this->xdebug_loaded = extension_loaded('xdebug');
 		$this->cc_archive_enabled = class_exists('Archive');
 
 		Kohana_View::set_global('xdebug_enabled', $this->xdebug_loaded);
@@ -109,9 +109,9 @@ Class Controller_UnitTest extends Controller_Template
 		// We don't want to use the HTML layout, we're sending the user 100111011100110010101100
 		$this->auto_render = FALSE;
 
-		$suite     = Kohana_Tests::suite();
+		$suite = Kohana_Tests::suite();
 		$temp_path = rtrim($this->config->temp_path, '/').'/';
-		$group     = (array) Arr::get($_GET, 'group', array());
+		$group = (array) Arr::get($_GET, 'group', array());
 
 		// Stop unittest from interpretting "all groups" as "no groups"
 		if (empty($group) OR empty($group[0]))
@@ -150,17 +150,13 @@ Class Controller_UnitTest extends Controller_Template
 		else
 		{
 			$folder = trim($this->config->cc_report_path, '/').'/';
-			$path   = DOCROOT.$folder;
+			$path = DOCROOT.$folder;
 
 			if ( ! file_exists($path))
-			{
 				throw new Kohana_Exception('Report directory :dir does not exist', array(':dir' => $path));
-			}
 
 			if ( ! is_writable($path))
-			{
 				throw new Kohana_Exception('Script doesn\'t have permission to write to report dir :dir ', array(':dir' => $path));
-			}
 
 			$runner->generate_report($group, $path, FALSE);
 
@@ -220,19 +216,19 @@ Class Controller_UnitTest extends Controller_Template
 		// Show some results
 		$this->template->body
 			->set('results', $runner->results)
-			->set('totals',  $runner->totals)
-			->set('time',    $this->nice_time($runner->time))
+			->set('totals', $runner->totals)
+			->set('time', $this->nice_time($runner->time))
 
 			// Sets group to the currently selected group, or default all groups
-			->set('group',  Arr::get($this->get_groups_list($suite), reset($group), 'All groups'))
+			->set('group', Arr::get($this->get_groups_list($suite), reset($group), 'All groups'))
 			->set('groups', $this->get_groups_list($suite))
 
-			->set('report_uri',     $this->report_uri.url::query())
+			->set('report_uri', $this->report_uri.url::query())
 
 			// Whitelist related stuff
 			->set('whitelistable_items', $this->get_whitelistable_items())
-			->set('whitelisted_items',   isset($whitelist) ? array_keys($whitelist) : array())
-			->set('whitelist',           ! empty($whitelist));
+			->set('whitelisted_items', isset($whitelist) ? array_keys($whitelist) : array())
+			->set('whitelist', ! empty($whitelist));
 	}
 
 	/**
@@ -262,9 +258,7 @@ Class Controller_UnitTest extends Controller_Template
 		static $whitelist;
 
 		if (count($whitelist))
-		{
 			return $whitelist;
-		}
 
 		$whitelist = array();
 

--- a/classes/kohana/tests.php
+++ b/classes/kohana/tests.php
@@ -132,7 +132,9 @@ class Kohana_Tests
 	 * @param PHPUnit_Framework_TestSuite  $suite   The test suite to add to
 	 * @param array                        $files   Array of files to test
 	 */
+	// @codingStandardsIgnoreStart
 	static function addTests(PHPUnit_Framework_TestSuite $suite, array $files)
+	// @codingStandardsIgnoreEnd
 	{
 		if (self::$phpunit_v35)
 		{

--- a/classes/kohana/unittest/database/testcase.php
+++ b/classes/kohana/unittest/database/testcase.php
@@ -7,8 +7,8 @@
  * @author     BRMatt <matthew@sigswitch.com>
  * @copyright  (c) 2008-2009 Kohana Team
  * @license    http://kohanaphp.com/license
- * @codingStandardsIgnoreFile
  */
+// @codingStandardsIgnoreFile
 Abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Database_TestCase {
 
 	/**

--- a/classes/kohana/unittest/database/testcase.php
+++ b/classes/kohana/unittest/database/testcase.php
@@ -7,6 +7,7 @@
  * @author     BRMatt <matthew@sigswitch.com>
  * @copyright  (c) 2008-2009 Kohana Team
  * @license    http://kohanaphp.com/license
+ * @codingStandardsIgnoreFile
  */
 Abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Database_TestCase {
 
@@ -43,9 +44,9 @@ Abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public function setUp()
 	{
-		if(self::$_assert_type_compatability === NULL)
+		if (self::$_assert_type_compatability === NULL)
 		{
-			if( ! class_exists('PHPUnit_Runner_Version'))
+			if ( ! class_exists('PHPUnit_Runner_Version'))
 			{
 				require_once 'PHPUnit/Runner/Version.php';
 			}
@@ -100,15 +101,15 @@ Abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 		return $this->createDefaultDBConnection($pdo, $config['connection']['database']);
 	}
 
-    /**
-     * Gets a connection to the unittest database
-     *
-     * @return Kohana_Database The database connection
-     */
-    public function getKohanaConnection()
-    {
-        return Database::instance(Kohana::config('unittest')->db_connection);
-    }
+	/**
+	 * Gets a connection to the unittest database
+	 *
+	 * @return Kohana_Database The database connection
+	 */
+	public function getKohanaConnection()
+	{
+		return Database::instance(Kohana::config('unittest')->db_connection);
+	}
 
 	/**
 	 * Removes all kohana related cache files in the cache directory
@@ -166,10 +167,8 @@ Abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertInstanceOf($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertType($expected, $actual, $message);
-		}
 
 		return parent::assertInstanceOf($expected, $actual, $message);
 	}
@@ -185,10 +184,8 @@ Abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertAttributeInstanceOf($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return parent::assertAttributeInstanceOf($expected, $attributeName, $classOrObject, $message);
 	}
@@ -203,10 +200,8 @@ Abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertNotInstanceOf($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertNotType($expected, $actual, $message);
-		}
 
 		return self::assertNotInstanceOf($expected, $actual, $message);
 	}
@@ -222,10 +217,8 @@ Abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertAttributeNotInstanceOf($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeNotType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return self::assertAttributeNotInstanceOf($expected, $attributeName, $classOrObject, $message);
 	}
@@ -240,10 +233,8 @@ Abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertInternalType($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertType($expected, $actual, $message);
-		}
 		
 		return parent::assertInternalType($expected, $actual, $message);
 	}
@@ -259,10 +250,8 @@ Abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertAttributeInternalType($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return self::assertAttributeInternalType($expected, $attributeName, $classOrObject, $message);
 	}
@@ -277,10 +266,8 @@ Abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertNotInternalType($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertNotType($expected, $actual, $message);
-		}
 
 		return self::assertNotInternalType($expected, $actual, $message);
 	}
@@ -296,10 +283,8 @@ Abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertAttributeNotInternalType($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeNotType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return self::assertAttributeNotInternalType($expected, $attributeName, $classOrObject, $message);
 	}

--- a/classes/kohana/unittest/helpers.php
+++ b/classes/kohana/unittest/helpers.php
@@ -139,7 +139,7 @@ class Kohana_Unittest_Helpers
 				$class->setStaticPropertyValue($var, $value);
 			}
 			// If this is an environment variable
-			elseif (preg_match('/^[A-Z_-]+$/', $option) OR isset($_SERVER[$option]))
+			elseif (preg_match('/^[A-Z_-]+$/D', $option) OR isset($_SERVER[$option]))
 			{
 				if ($backup_needed)
 				{

--- a/classes/kohana/unittest/runner.php
+++ b/classes/kohana/unittest/runner.php
@@ -221,43 +221,54 @@ Class Kohana_Unittest_Runner implements PHPUnit_Framework_TestListener
 		return $this;
 	}
 
+	// @codingStandardsIgnoreStart
 	public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
+	// @codingStandardsIgnoreEnd
 	{
 		$this->totals['errors']++;
 		$this->current['result'] = 'errors';
 		$this->current['message'] = $test->getStatusMessage();
-
 	}
 
+	// @codingStandardsIgnoreStart
 	public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
+	// @codingStandardsIgnoreEnd
 	{
 		$this->totals['failures']++;
 		$this->current['result'] = 'failures';
 		$this->current['message'] = $test->getStatusMessage();
 	}
 
+	// @codingStandardsIgnoreStart
 	public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+	// @codingStandardsIgnoreEnd
 	{
 		$this->totals['incomplete']++;
 		$this->current['result'] = 'incomplete';
 		$this->current['message'] = $test->getStatusMessage();
 	}
 
+	// @codingStandardsIgnoreStart
 	public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+	// @codingStandardsIgnoreEnd
 	{
 		$this->totals['skipped']++;
 		$this->current['result'] = 'skipped';
 		$this->current['message'] = $test->getStatusMessage();
 	}
 
+	// @codingStandardsIgnoreStart
 	public function startTest(PHPUnit_Framework_Test $test)
+	// @codingStandardsIgnoreEnd
 	{
 		$this->current['name'] = $test->getName(FALSE);
 		$this->current['description'] = $test->toString();
 		$this->current['result'] = 'passed';
 	}
 
+	// @codingStandardsIgnoreStart
 	public function endTest(PHPUnit_Framework_Test $test, $time)
+	// @codingStandardsIgnoreEnd
 	{
 		// Add totals
 		$this->totals['tests']++;
@@ -280,11 +291,13 @@ Class Kohana_Unittest_Runner implements PHPUnit_Framework_TestListener
 		$this->time += $time;
 	}
 
-	public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
-	{
-	}
+	// @codingStandardsIgnoreStart
+	public function startTestSuite(PHPUnit_Framework_TestSuite $suite) {}
+	// @codingStandardsIgnoreEnd
 
+	// @codingStandardsIgnoreStart
 	public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
+	// @codingStandardsIgnoreEnd
 	{
 		// Parse test descriptions to make them look nicer
 		foreach ($this->results as $case => $testresults)

--- a/classes/kohana/unittest/runner.php
+++ b/classes/kohana/unittest/runner.php
@@ -160,9 +160,7 @@ Class Kohana_Unittest_Runner implements PHPUnit_Framework_TestListener
 	public function generate_report(array $groups, $temp_path, $create_sub_dir = TRUE)
 	{
 		if ( ! is_writable($temp_path))
-		{
 			throw new Kohana_Exception('Temp path :path does not exist or is not writable by the webserver', array(':path' => $temp_path));
-		}
 
 		$folder_path = $temp_path;
 
@@ -209,9 +207,7 @@ Class Kohana_Unittest_Runner implements PHPUnit_Framework_TestListener
 	public function run(array $groups = array(), $collect_cc = FALSE)
 	{
 		if ($collect_cc AND ! extension_loaded('xdebug'))
-		{
 			throw new Kohana_Exception('Code coverage cannot be collected because the xdebug extension is not loaded');
-		}
 
 		$this->result->collectCodeCoverageInformation( (bool) $collect_cc);
 

--- a/classes/kohana/unittest/testcase.php
+++ b/classes/kohana/unittest/testcase.php
@@ -9,6 +9,7 @@
  * @copyright  (c) 2008-2009 Kohana Team
  * @license    http://kohanaphp.com/license
  */
+// @codingStandardsIgnoreFile
 abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	
 	/**
@@ -44,9 +45,9 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public function setUp()
 	{
-		if(self::$_assert_type_compatability === NULL)
+		if (self::$_assert_type_compatability === NULL)
 		{
-			if( ! class_exists('PHPUnit_Runner_Version'))
+			if ( ! class_exists('PHPUnit_Runner_Version'))
 			{
 				require_once 'PHPUnit/Runner/Version.php';
 			}
@@ -126,10 +127,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertInstanceOf($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertType($expected, $actual, $message);
-		}
 
 		return parent::assertInstanceOf($expected, $actual, $message);
 	}
@@ -145,10 +144,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertAttributeInstanceOf($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return parent::assertAttributeInstanceOf($expected, $attributeName, $classOrObject, $message);
 	}
@@ -163,10 +160,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertNotInstanceOf($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertNotType($expected, $actual, $message);
-		}
 
 		return self::assertNotInstanceOf($expected, $actual, $message);
 	}
@@ -182,10 +177,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertAttributeNotInstanceOf($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeNotType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return self::assertAttributeNotInstanceOf($expected, $attributeName, $classOrObject, $message);
 	}
@@ -200,10 +193,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertInternalType($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertType($expected, $actual, $message);
-		}
 		
 		return parent::assertInternalType($expected, $actual, $message);
 	}
@@ -219,10 +210,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertAttributeInternalType($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return self::assertAttributeInternalType($expected, $attributeName, $classOrObject, $message);
 	}
@@ -237,10 +226,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertNotInternalType($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertNotType($expected, $actual, $message);
-		}
 
 		return self::assertNotInternalType($expected, $actual, $message);
 	}
@@ -256,10 +243,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertAttributeNotInternalType($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeNotType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return self::assertAttributeNotInternalType($expected, $attributeName, $classOrObject, $message);
 	}


### PR DESCRIPTION
These commits should eliminate all coding standards violations from the unittest module, either by correcting them or ignoring them.  

This should resolve: http://dev.kohanaframework.org/issues/3717
