### PR TITLE
Eliminating coding standard violations from unittest module (3.1)

### DIFF
--- a/classes/controller/unittest.php
+++ b/classes/controller/unittest.php
@@ -73,10 +73,10 @@ class Controller_UnitTest extends Controller_Template
 		// This just stops some very very long lines
 		$route = Route::get('unittest');
 		$this->report_uri = $route->uri(array('action' => 'report'));
-		$this->run_uri    = $route->uri(array('action' => 'run'));
+		$this->run_uri = $route->uri(array('action' => 'run'));
 
 		// Switch used to disable cc settings
-		$this->xdebug_loaded      = extension_loaded('xdebug');
+		$this->xdebug_loaded = extension_loaded('xdebug');
 		$this->cc_archive_enabled = class_exists('Archive');
 
 		Kohana_View::set_global('xdebug_enabled', $this->xdebug_loaded);
@@ -102,16 +102,14 @@ class Controller_UnitTest extends Controller_Template
 	{
 		// Fairly foolproof
 		if ( ! $this->config->cc_report_path AND ! class_exists('Archive'))
-		{
 			throw new Kohana_Exception('Cannot generate report');
-		}
 
 		// We don't want to use the HTML layout, we're sending the user 100111011100110010101100
 		$this->auto_render = FALSE;
 
-		$suite     = Unittest_tests::suite();
+		$suite = Unittest_tests::suite();
 		$temp_path = rtrim($this->config->temp_path, '/').'/';
-		$group     = (array) Arr::get($_GET, 'group', array());
+		$group = (array) Arr::get($_GET, 'group', array());
 
 		// Stop unittest from interpretting "all groups" as "no groups"
 		if (empty($group) OR empty($group[0]))
@@ -150,17 +148,13 @@ class Controller_UnitTest extends Controller_Template
 		else
 		{
 			$folder = trim($this->config->cc_report_path, '/').'/';
-			$path   = DOCROOT.$folder;
+			$path = DOCROOT.$folder;
 
 			if ( ! file_exists($path))
-			{
 				throw new Kohana_Exception('Report directory :dir does not exist', array(':dir' => $path));
-			}
 
 			if ( ! is_writable($path))
-			{
 				throw new Kohana_Exception('Script doesn\'t have permission to write to report dir :dir ', array(':dir' => $path));
-			}
 
 			$runner->generate_report($group, $path, FALSE);
 
@@ -220,20 +214,20 @@ class Controller_UnitTest extends Controller_Template
 		// Show some results
 		$this->template->body
 			->set('results', $runner->results)
-			->set('totals',  $runner->totals)
-			->set('time',    $this->nice_time($runner->time))
+			->set('totals', $runner->totals)
+			->set('time', $this->nice_time($runner->time))
 
 			// Sets group to the currently selected group, or default all groups
-			->set('group',  Arr::get($this->get_groups_list($suite), reset($group), 'All groups'))
+			->set('group', Arr::get($this->get_groups_list($suite), reset($group), 'All groups'))
 			->set('groups', $this->get_groups_list($suite))
 
-			->set('run_uri',        $this->request->uri())
-			->set('report_uri',     $this->report_uri.url::query())
+			->set('run_uri', $this->request->uri())
+			->set('report_uri', $this->report_uri.url::query())
 
 			// Whitelist related stuff
 			->set('whitelistable_items', $this->get_whitelistable_items())
-			->set('whitelisted_items',   isset($whitelist) ? array_keys($whitelist) : array())
-			->set('whitelist',           ! empty($whitelist));
+			->set('whitelisted_items', isset($whitelist) ? array_keys($whitelist) : array())
+			->set('whitelist', ! empty($whitelist));
 	}
 
 	/**
@@ -263,9 +257,7 @@ class Controller_UnitTest extends Controller_Template
 		static $whitelist;
 
 		if (count($whitelist))
-		{
 			return $whitelist;
-		}
 
 		$whitelist = array();
 

--- a/classes/kohana/unittest/database/testcase.php
+++ b/classes/kohana/unittest/database/testcase.php
@@ -8,6 +8,7 @@
  * @copyright  (c) 2008-2009 Kohana Team
  * @license    http://kohanaphp.com/license
  */
+// @codingStandardsIgnoreFile
 abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Database_TestCase {
 
 	/**
@@ -43,9 +44,9 @@ abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public function setUp()
 	{
-		if(self::$_assert_type_compatability === NULL)
+		if (self::$_assert_type_compatability === NULL)
 		{
-			if( ! class_exists('PHPUnit_Runner_Version'))
+			if ( ! class_exists('PHPUnit_Runner_Version'))
 			{
 				require_once 'PHPUnit/Runner/Version.php';
 			}
@@ -100,15 +101,15 @@ abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 		return $this->createDefaultDBConnection($pdo, $config['connection']['database']);
 	}
 
-    /**
-     * Gets a connection to the unittest database
-     *
-     * @return Kohana_Database The database connection
-     */
-    public function getKohanaConnection()
-    {
-        return Database::instance(Kohana::config('unittest')->db_connection);
-    }
+	/**
+	 * Gets a connection to the unittest database
+	 *
+	 * @return Kohana_Database The database connection
+	 */
+	public function getKohanaConnection()
+	{
+		return Database::instance(Kohana::config('unittest')->db_connection);
+	}
 
 	/**
 	 * Removes all kohana related cache files in the cache directory
@@ -166,10 +167,8 @@ abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertInstanceOf($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertType($expected, $actual, $message);
-		}
 
 		return parent::assertInstanceOf($expected, $actual, $message);
 	}
@@ -185,10 +184,8 @@ abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertAttributeInstanceOf($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return parent::assertAttributeInstanceOf($expected, $attributeName, $classOrObject, $message);
 	}
@@ -203,10 +200,8 @@ abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertNotInstanceOf($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertNotType($expected, $actual, $message);
-		}
 
 		return self::assertNotInstanceOf($expected, $actual, $message);
 	}
@@ -222,10 +217,8 @@ abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertAttributeNotInstanceOf($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeNotType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return self::assertAttributeNotInstanceOf($expected, $attributeName, $classOrObject, $message);
 	}
@@ -240,10 +233,8 @@ abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertInternalType($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertType($expected, $actual, $message);
-		}
 		
 		return parent::assertInternalType($expected, $actual, $message);
 	}
@@ -259,10 +250,8 @@ abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertAttributeInternalType($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return self::assertAttributeInternalType($expected, $attributeName, $classOrObject, $message);
 	}
@@ -277,10 +266,8 @@ abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertNotInternalType($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertNotType($expected, $actual, $message);
-		}
 
 		return self::assertNotInternalType($expected, $actual, $message);
 	}
@@ -296,10 +283,8 @@ abstract Class Kohana_Unittest_Database_TestCase extends PHPUnit_Extensions_Data
 	 */
 	public static function assertAttributeNotInternalType($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeNotType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return self::assertAttributeNotInternalType($expected, $attributeName, $classOrObject, $message);
 	}

--- a/classes/kohana/unittest/helpers.php
+++ b/classes/kohana/unittest/helpers.php
@@ -132,7 +132,7 @@ class Kohana_Unittest_Helpers {
 				$class->setStaticPropertyValue($var, $value);
 			}
 			// If this is an environment variable
-			elseif (preg_match('/^[A-Z_-]+$/', $option) OR isset($_SERVER[$option]))
+			elseif (preg_match('/^[A-Z_-]+$/D', $option) OR isset($_SERVER[$option]))
 			{
 				if ($backup_needed)
 				{

--- a/classes/kohana/unittest/runner.php
+++ b/classes/kohana/unittest/runner.php
@@ -160,9 +160,7 @@ class Kohana_Unittest_Runner implements PHPUnit_Framework_TestListener {
 	public function generate_report(array $groups, $temp_path, $create_sub_dir = TRUE)
 	{
 		if ( ! is_writable($temp_path))
-		{
 			throw new Kohana_Exception('Temp path :path does not exist or is not writable by the webserver', array(':path' => $temp_path));
-		}
 
 		$folder_path = $temp_path;
 
@@ -209,9 +207,7 @@ class Kohana_Unittest_Runner implements PHPUnit_Framework_TestListener {
 	public function run(array $groups = array(), $collect_cc = FALSE)
 	{
 		if ($collect_cc AND ! extension_loaded('xdebug'))
-		{
 			throw new Kohana_Exception('Code coverage cannot be collected because the xdebug extension is not loaded');
-		}
 
 		$this->result->collectCodeCoverageInformation( (bool) $collect_cc);
 
@@ -221,42 +217,54 @@ class Kohana_Unittest_Runner implements PHPUnit_Framework_TestListener {
 		return $this;
 	}
 
+	// @codingStandardsIgnoreStart
 	public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
+	// @codingStandardsIgnoreEnd
 	{
 		$this->totals['errors']++;
 		$this->current['result'] = 'errors';
 		$this->current['message'] = $test->getStatusMessage();
 	}
 
+	// @codingStandardsIgnoreStart
 	public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
+	// @codingStandardsIgnoreEnd
 	{
 		$this->totals['failures']++;
 		$this->current['result'] = 'failures';
 		$this->current['message'] = $test->getStatusMessage();
 	}
 
+	// @codingStandardsIgnoreStart
 	public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+	// @codingStandardsIgnoreEnd
 	{
 		$this->totals['incomplete']++;
 		$this->current['result'] = 'incomplete';
 		$this->current['message'] = $test->getStatusMessage();
 	}
 
+	// @codingStandardsIgnoreStart
 	public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+	// @codingStandardsIgnoreEnd
 	{
 		$this->totals['skipped']++;
 		$this->current['result'] = 'skipped';
 		$this->current['message'] = $test->getStatusMessage();
 	}
 
+	// @codingStandardsIgnoreStart
 	public function startTest(PHPUnit_Framework_Test $test)
+	// @codingStandardsIgnoreEnd
 	{
 		$this->current['name'] = $test->getName(FALSE);
 		$this->current['description'] = $test->toString();
 		$this->current['result'] = 'passed';
 	}
 
+	// @codingStandardsIgnoreStart
 	public function endTest(PHPUnit_Framework_Test $test, $time)
+	// @codingStandardsIgnoreEnd
 	{
 		// Add totals
 		$this->totals['tests']++;
@@ -279,11 +287,13 @@ class Kohana_Unittest_Runner implements PHPUnit_Framework_TestListener {
 		$this->time += $time;
 	}
 
-	public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
-	{
-	}
+	// @codingStandardsIgnoreStart
+	public function startTestSuite(PHPUnit_Framework_TestSuite $suite) {}
+	// @codingStandardsIgnoreEnd
 
+	// @codingStandardsIgnoreStart
 	public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
+	// @codingStandardsIgnoreEnd
 	{
 		// Parse test descriptions to make them look nicer
 		foreach ($this->results as $case => $testresults)

--- a/classes/kohana/unittest/testcase.php
+++ b/classes/kohana/unittest/testcase.php
@@ -4,6 +4,7 @@
  * A version of the stock PHPUnit testcase that includes some extra helpers
  * and default settings
  */
+// @codingStandardsIgnoreFile
 abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	
 	/**
@@ -39,9 +40,9 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public function setUp()
 	{
-		if(self::$_assert_type_compatability === NULL)
+		if (self::$_assert_type_compatability === NULL)
 		{
-			if( ! class_exists('PHPUnit_Runner_Version'))
+			if ( ! class_exists('PHPUnit_Runner_Version'))
 			{
 				require_once 'PHPUnit/Runner/Version.php';
 			}
@@ -121,10 +122,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertInstanceOf($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertType($expected, $actual, $message);
-		}
 
 		return parent::assertInstanceOf($expected, $actual, $message);
 	}
@@ -140,10 +139,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertAttributeInstanceOf($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return parent::assertAttributeInstanceOf($expected, $attributeName, $classOrObject, $message);
 	}
@@ -158,10 +155,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertNotInstanceOf($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertNotType($expected, $actual, $message);
-		}
 
 		return self::assertNotInstanceOf($expected, $actual, $message);
 	}
@@ -177,10 +172,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertAttributeNotInstanceOf($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeNotType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return self::assertAttributeNotInstanceOf($expected, $attributeName, $classOrObject, $message);
 	}
@@ -195,10 +188,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertInternalType($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertType($expected, $actual, $message);
-		}
 		
 		return parent::assertInternalType($expected, $actual, $message);
 	}
@@ -214,10 +205,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertAttributeInternalType($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return self::assertAttributeInternalType($expected, $attributeName, $classOrObject, $message);
 	}
@@ -232,10 +221,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertNotInternalType($expected, $actual, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertNotType($expected, $actual, $message);
-		}
 
 		return self::assertNotInternalType($expected, $actual, $message);
 	}
@@ -251,10 +238,8 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public static function assertAttributeNotInternalType($expected, $attributeName, $classOrObject, $message = '')
 	{
-		if(self::$_assert_type_compatability)
-		{
+		if (self::$_assert_type_compatability)
 			return self::assertAttributeNotType($expected, $attributeName, $classOrObject, $message);
-		}
 
 		return self::assertAttributeNotInternalType($expected, $attributeName, $classOrObject, $message);
 	}

--- a/classes/kohana/unittest/tests.php
+++ b/classes/kohana/unittest/tests.php
@@ -131,7 +131,9 @@ class Kohana_Unittest_Tests {
 	 * @param PHPUnit_Framework_TestSuite  $suite   The test suite to add to
 	 * @param array                        $files   Array of files to test
 	 */
+	// @codingStandardsIgnoreStart
 	static function addTests(PHPUnit_Framework_TestSuite $suite, array $files)
+	// @codingStandardsIgnoreEnd
 	{
 		if (self::$phpunit_v35)
 		{


### PR DESCRIPTION
These commits should eliminate all coding standards violations from the unittest module, either by correcting them or ignoring them.

This should resolve: http://dev.kohanaframework.org/issues/3798
