### PR TITLE
Only ob_end_flush() if the buffer is not empty. Fixes 'headers already se

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -107,7 +107,18 @@ if ( ! defined('KOHANA_START_MEMORY'))
 require APPPATH.'bootstrap'.EXT;
 
 // Disable output buffering
-ob_end_flush();
+if (($ob_len = ob_get_length()) !== FALSE)
+{
+	// flush_end on an empty buffer causes headers to be sent. Only flush if needed.
+	if ($ob_len > 0)
+	{
+		ob_end_flush();
+	}
+	else
+	{
+		ob_end_clean();
+	}
+}
 
 // Enable the unittest module
 Kohana::modules(Kohana::modules() + array('unittest' => MODPATH.'unittest'));


### PR DESCRIPTION
Only ob_end_flush() if the buffer is not empty. Fixes 'headers already sent' warnings.
