### PR TITLE
Exclude php files under test_data when building suite - fixes #4232

### DIFF
--- a/classes/kohana/unittest/tests.php
+++ b/classes/kohana/unittest/tests.php
@@ -81,7 +81,7 @@ class Kohana_Unittest_Tests {
 		{
 			return $suite;
 		}
-		
+
 		Unittest_Tests::configure_environment();
 
 		$files = Kohana::list_files('tests');
@@ -108,11 +108,14 @@ class Kohana_Unittest_Tests {
 			$filter = PHP_CodeCoverage_Filter::getInstance();
 		}
 
-		foreach ($files as $file)
+		foreach ($files as $path => $file)
 		{
 			if (is_array($file))
 			{
-				self::addTests($suite, $file);
+				if ($path != 'tests/test_data')
+				{
+					self::addTests($suite, $file);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
See ticket at http://dev.kohanaframework.org/issues/4232 - this commit excludes the tests/test_data directory when building the test suite, to allow more flexibility for php files within this path.
