### PR TITLE
Use DIRECTORY_SEPARATOR when excluding php files under test_data - issue with fix for #4232

### DIFF
--- a/classes/kohana/unittest/tests.php
+++ b/classes/kohana/unittest/tests.php
@@ -112,8 +112,8 @@ class Kohana_Unittest_Tests {
 		{
 			if (is_array($file))
 			{
-				if ($path != 'tests/test_data')
-				{
+				if ($path != 'tests'.DIRECTORY_SEPARATOR.'test_data')
+				{					
 					self::addTests($suite, $file);
 				}
 			}


### PR DESCRIPTION
Apologies, I should have thought ahead - the commit that I submitted in [Pull request 12 - Exclude php files under test_data when building suite - fixes #4232](https://github.com/kohana/unittest/pull/12) should have used DIRECTORY_SEPARATOR rather than a hardcoded / in the path.

With this commit the fix for #4232 is now platform independent.
