### PR TITLE
Only ob_end_flush() if the buffer is not empty.

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -108,7 +108,18 @@ if ( ! defined('KOHANA_START_MEMORY'))
 require APPPATH.'bootstrap'.EXT;
 
 // Disable output buffering
-ob_end_flush();
+if (($ob_len = ob_get_length()) !== FALSE)
+{
+	// flush_end on an empty buffer causes headers to be sent. Only flush if needed.
+	if ($ob_len > 0)
+	{
+		ob_end_flush();
+	}
+	else
+	{
+		ob_end_clean();
+	}
+}
 
 // Enable the unittest module
 Kohana::modules(Kohana::modules() + array('unittest' => MODPATH.'unittest'));


### PR DESCRIPTION
Only ob_end_flush() if the buffer is not empty. Fixes 'headers already sent' warnings.

Ticket [#4237](http://dev.kohanaframework.org/issues/4237).

Previous pull request: https://github.com/kohana/unittest/pull/11
