### PR TITLE
Support PHPUnit 3.6 by moving Code Coverage filtering into the test suite

### DIFF
--- a/classes/kohana/unittest/testsuite.php
+++ b/classes/kohana/unittest/testsuite.php
@@ -33,16 +33,20 @@ abstract class Kohana_Unittest_TestSuite extends PHPUnit_Framework_TestSuite
 		
 		// Get the code coverage filter from the suite's result object
 		$coverage = $result->getCodeCoverage();
-		$coverage_filter = $coverage->filter();
 		
-		// Apply the white and blacklisting
-		foreach ($this->_filter_calls as $method => $args)
+		if ($coverage)
 		{
-			foreach ($args as $arg)
+			$coverage_filter = $coverage->filter();
+
+			// Apply the white and blacklisting
+			foreach ($this->_filter_calls as $method => $args)
 			{
-				$coverage_filter->$method($arg);
+				foreach ($args as $arg)
+				{
+					$coverage_filter->$method($arg);
+				}
 			}
-		}		
+		}
 		
 		return parent::run($result, $filter, $groups, $excludeGroups, $processIsolation);
 	}

--- a/classes/kohana/unittest/testsuite.php
+++ b/classes/kohana/unittest/testsuite.php
@@ -1,0 +1,76 @@
+<?php defined('SYSPATH') or die('No direct script access.');
+
+/**
+ * A version of the stock PHPUnit testsuite that supports whitelisting and 
+ * blacklisting for code coverage filter
+ */
+abstract class Kohana_Unittest_TestSuite extends PHPUnit_Framework_TestSuite 
+{
+	/**
+	 * Holds the details of files that should be white and blacklisted for
+	 * code coverage
+	 * 
+	 * @var array
+	 */
+	protected $_filter_calls = array(
+		'addFileToBlacklist' => array(),
+		'addDirectoryToBlacklist' => array(),
+		'addFileToWhitelist' => array());
+	
+	/**
+     * Runs the tests and collects their result in a TestResult.
+     *
+     * @param  PHPUnit_Framework_TestResult $result
+     * @param  mixed                        $filter
+     * @param  array                        $groups
+     * @param  array                        $excludeGroups
+     * @param  boolean                      $processIsolation
+     * @return PHPUnit_Framework_TestResult
+     * @throws InvalidArgumentException
+     */
+    public function run(PHPUnit_Framework_TestResult $result = NULL, $filter = FALSE, array $groups = array(), array $excludeGroups = array(), $processIsolation = FALSE)
+    {
+		
+		// Get the code coverage filter from the suite's result object
+		$coverage = $result->getCodeCoverage();
+		$coverage_filter = $coverage->filter();
+		
+		// Apply the white and blacklisting
+		foreach ($this->_filter_calls as $method => $args)
+		{
+			foreach ($args as $arg)
+			{
+				$coverage_filter->$method($arg);
+			}
+		}		
+		
+		return parent::run($result, $filter, $groups, $excludeGroups, $processIsolation);
+	}
+	
+	/**
+	 * Queues a file to be added to the code coverage blacklist when the suite runs
+	 * @param string $file 
+	 */
+	public function addFileToBlacklist($file)
+	{
+		$this->_filter_calls['addFileToBlacklist'][] = $file;
+	}
+
+	/**
+	 * Queues a directory to be added to the code coverage blacklist when the suite runs
+	 * @param string $dir
+	 */
+	public function addDirectoryToBlacklist($dir)
+	{
+		$this->_filter_calls['addDirectoryToBlacklist'][] = $dir;
+	}
+	
+	/**
+	 * Queues a file to be added to the code coverage whitelist when the suite runs
+	 * @param string $file 
+	 */
+	public function addFileToWhitelist($file)
+	{
+		$this->_filter_calls['addFileToWhitelist'][] = $file;
+	}
+}

--- a/classes/unittest/testsuite.php
+++ b/classes/unittest/testsuite.php
@@ -1,0 +1,3 @@
+<?php defined('SYSPATH') OR die('No direct script access.');
+
+class Unittest_TestSuite extends Kohana_Unittest_TestSuite {}


### PR DESCRIPTION
As per this ticket http://dev.kohanaframework.org/issues/4323 PHPUnit 3.6 has removed the singleton for the code coverage filter, so this module is not compatible.

The filter is created just before the test suite is executed, and is stored in the result object that is passed into PHPUnit_Framework_TestSuite::run.

This pull therefore moves the processing of white and blacklisting into a new Kohana_Unittest_TestSuite class that stores up the calls and applies them to the code coverage filter when the suite is executed. The good news is that this approach is backwards compatible for PHPUnit 3.5 too - I haven't tested with PHPUnit 3.4 but I've left that code untouched so there should be no change to how well it works. I don't know if you'll want to retire support for PHPUnit 3.4 at some point, which would allow some of this to be made much simpler.
