### PR TITLE
Change default value of use_whitelist to false

### DIFF
--- a/config/unittest.php
+++ b/config/unittest.php
@@ -4,7 +4,6 @@ return array(
 
 	// If you don't use a whitelist then only files included during the request will be counted
 	// If you do, then only whitelisted items will be counted
-	// By default this is FALSE so that a phpunit.xml file can set the whitelist
 	'use_whitelist' => TRUE,
 
 	// Items to whitelist, only used in cli


### PR DESCRIPTION
The comments note that the default value should be false so that the
whitelist can be set in phpunit.xml, so this change reflects that
comment.

Fixes #4363
