### PR TITLE
Defining $vendor_path for unit testing

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+$vendor_path = 'vendor/';
+
 /**
  * The directory in which your application specific resources are located.
  * The application directory must contain the bootstrap.php file.
@@ -21,7 +23,7 @@ $modules = 'modules';
  *
  * @link http://kohanaframework.org/guide/about.install#system
  */
-$system = 'vendor/kohana/core';
+$system = $vendor_path.'kohana/core';
 
 /**
  * The default extension of resource files. If you change this, all resources


### PR DESCRIPTION
This is analogous to what is in DOCROOT.'index.php'  for regular application execution. $vendor_path must be defined in order to use any of the modules setup in application/bootstrap.php  Kohana::modules() call
