### PR TITLE
Provide basic integration testing with Request and Response objects.

### DIFF
--- a/classes/Kohana/Unittest/Integration/TestCase.php
+++ b/classes/Kohana/Unittest/Integration/TestCase.php
@@ -1,0 +1,73 @@
+<?php defined('SYSPATH') or die('No direct script access.');
+
+/**
+ * TestCase for testing in integration with Request and Response objects.
+ *
+ * This is inspired from the Play framework in which a test case provides
+ * primitives to test Response objects.
+ *
+ * Testing a real application is feasible by self-requesting endpoints and
+ * asserting pre-conditions and post-conditions.
+ *
+ * @package    Kohana/UnitTest
+ * @author     Guillaume Poirier-Morency <guillaumepoiriermorency@gmail.com>
+ * @copyright  (c) 2008-2009 Kohana Team
+ * @license    http://kohanaphp.com/license
+ */
+abstract class Kohana_Unittest_Integration_TestCase extends Unittest_TestCase {
+
+	/**
+	 * Assert that a given Response status match the expected value.
+	 *
+	 * @param integer  $code     expected status code
+	 * @param Response $response Response object
+	 * @param string   $message  message displayed if the test fail
+	 */
+	public function assertStatus($code, Response $response, $message = NULL)
+	{
+		if ($message === NULL)
+		{
+			$message = $response->body();
+		}
+
+		$this->assertEquals($code, $response->status(), $message);
+	}
+
+	public function assertOk(Response $response, $message = NULL)
+	{
+		$this->assertStatus(200, $response, $message);
+	}
+
+	public function assertPermanentRedirection($location, Response $response, $message = NULL)
+	{
+		$this->assertStatus(301, $response, $message);
+		$this->assertEquals($location, $response->headers('Location'));
+	}
+
+	public function assertTemporaryRedirection($location, Response $response, $message = NULL)
+	{
+		$this->assertStatus(302, $response, $message);
+		$this->assertEquals($location, $response->headers('Location'));
+	}
+
+	public function assertUnauthorized(Response $response, $message = NULL)
+	{
+		$this->assertStatus(401, $response, $message);
+	}
+
+	public function assertForbidden(Response $response, $message = NULL)
+	{
+		$this->assertStatus(403, $response, $message);
+	}
+
+	public function assertNotFound(Response $response, $message = NULL)
+	{
+		$this->assertStatus(404, $response, $message);
+	}
+
+	public function assertServiceUnavailable(Response $response, $message = NULL)
+	{
+		$this->assertStatus(503, $response, $message);
+	}
+
+}

--- a/classes/Unittest/Integration/TestCase.php
+++ b/classes/Unittest/Integration/TestCase.php
@@ -1,0 +1,3 @@
+<?php defined('SYSPATH') or die('No direct script access.');
+
+abstract class Unittest_Integration_TestCase extends Kohana_Unittest_Integration_TestCase {}


### PR DESCRIPTION
This is a proposal for a skeleton `TestCase` that would be used to do integration testing with Kohana application.

I managed to test my application by self-requesting using internal `Request` just like the following:

``` php
$response = Request::factory('some/internal/endpoint')
    ->method(Request::POST)
    ->post('key', 'value')
    ->execute();

$this->assertEquals(200, $response->status(), $response->body());
```

But this gets a little messy and a lot of work has to be duplicated (especially for other status codes).

What I propose is a simple `TestCase_Integration` that would provide primitives for testing `Response` objects, making building and testing quality application simpler.

``` php
$this->assertOk($response);
$this->assertPermanentRedirect('http://some/location', $response);
```

I would like to have your insights on the matter!
