### PR TITLE
Override assertTag and assertNotTag to remove deprecation errors

### DIFF
--- a/classes/Kohana/Unittest/TestCase.php
+++ b/classes/Kohana/Unittest/TestCase.php
@@ -258,4 +258,77 @@ abstract class Kohana_Unittest_TestCase extends PHPUnit_Framework_TestCase {
 
 		return parent::assertAttributeNotInternalType($expected, $attributeName, $classOrObject, $message);
 	}
+
+	/**
+	 * Evaluate an HTML or XML string and assert its structure and/or contents.
+	 *
+	 * NOTE:
+	 * Overriding this method to remove the deprecation error
+	 * when tested with PHPUnit 4.2.0+
+	 *
+	 * TODO:
+	 * this should be removed when phpunit-dom-assertions gets released
+	 * https://github.com/phpunit/phpunit-dom-assertions
+	 *
+	 * @param array $matcher
+	 * @param string $actual
+	 * @param string $message
+	 * @param bool $isHtml
+	 * @uses Unittest_TestCase::tag_match
+	 */
+	public static function assertTag($matcher, $actual, $message = '', $isHtml = true)
+	{
+		//trigger_error(__METHOD__ . ' is deprecated', E_USER_DEPRECATED);
+
+		$matched = static::tag_match($matcher, $actual, $message, $isHtml);
+		static::assertTrue($matched, $message);
+	}
+
+	/**
+	 * This assertion is the exact opposite of assertTag
+	 *
+	 * Rather than asserting that $matcher results in a match, it asserts that
+	 * $matcher does not match
+	 *
+	 * NOTE:
+	 * Overriding this method to remove the deprecation error
+	 * when tested with PHPUnit 4.2.0+
+	 *
+	 * TODO:
+	 * this should be removed when phpunit-dom-assertions gets released
+	 * https://github.com/phpunit/phpunit-dom-assertions
+	 *
+	 * @param array $matcher
+	 * @param string $actual
+	 * @param string $message
+	 * @param bool $isHtml
+	 * @uses Unittest_TestCase::tag_match
+	 */
+	public static function assertNotTag($matcher, $actual, $message = '', $isHtml = true)
+	{
+		//trigger_error(__METHOD__ . ' is deprecated', E_USER_DEPRECATED);
+
+		$matched = static::tag_match($matcher, $actual, $message, $isHtml);
+		static::assertFalse($matched, $message);
+	}
+
+	/**
+	 * Helper function to match HTML string tags against certain criteria
+	 *
+	 * TODO:
+	 * this should be removed when phpunit-dom-assertions gets released
+	 * https://github.com/phpunit/phpunit-dom-assertions
+	 *
+	 * @param array $matcher
+	 * @param string $actual
+	 * @param string $message
+	 * @param bool $isHtml
+	 * @return bool TRUE if there is a match FALSE otherwise
+	 */
+	protected static function tag_match($matcher, $actual, $message = '', $isHtml = true)
+	{
+		$dom = PHPUnit_Util_XML::load($actual, $isHtml);
+		$tags = PHPUnit_Util_XML::findNodes($dom, $matcher, $isHtml);
+		return count($tags) > 0 && $tags[0] instanceof DOMNode;
+	}
 }


### PR DESCRIPTION
When running Kohana test suite with newer PHPUnit the assertion
methods `assertTag` and `assertNotTag` raise deprecation errors.

This is a patch to avoid the errors until phpunit-dom-assertions
gets released which should provide alternatives.
