### PR TITLE
Require mikey179/vfsStream package for unit testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
 	"require": {
 		"composer/installers": "~1.0",
 		"kohana/core":         ">=3.4",
+		"mikey179/vfsStream":  "^1.6",
 		"php":                 ">=5.4.0",
 		"phpunit/phpunit":     "^4.3",
 		"phpunit/phpunit-mock-objects": ">=2.0.3"


### PR DESCRIPTION
Per kohana/core@430a1d2 the vfsStream package is now required so that
unit tests that interact with the filesystem (Log_File initially) can use a 
virtual in-memory filesystem for easier setup and test independence.

Requiring this in kohana/unittest resolves kohana/core#651 by ensuring it's
present for all module builds (which also run the kohana/core tests).
